### PR TITLE
Security Fix for Prototype Pollution

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -143,6 +143,9 @@ exports.unset = function(path, o) {
     if (cur == null || typeof cur !== 'object' || !(parts[i] in cur)) {
       return false;
     }
+    if (typeof parts[i] !== 'string' && typeof parts[i] !== 'number') {
+      parts[i] = String(parts[i]);
+    }
     // Disallow any updates to __proto__ or special properties.
     if (ignoreProperties.indexOf(parts[i]) !== -1) {
       return false;
@@ -193,6 +196,9 @@ exports.set = function(path, val, o, special, map, _copying) {
   if (null == o) return;
 
   for (var i = 0; i < parts.length; ++i) {
+    if (typeof parts[i] !== 'string' && typeof parts[i] !== 'number') {
+      parts[i] = String(parts[i]);
+    }
     // Silently ignore any updates to `__proto__`, these are potentially
     // dangerous if using mpath with unsanitized data.
     if (ignoreProperties.indexOf(parts[i]) !== -1) {


### PR DESCRIPTION
Fix prototype pollution when path components are not strings